### PR TITLE
Add validation for numeric config values

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -47,3 +47,24 @@ if (!SUPPORTED_LANGUAGES.includes(config.language as any)) {
   );
   process.exit(1);
 }
+
+if (isNaN(config.checkIntervalMinutes) || config.checkIntervalMinutes <= 0) {
+  console.error(
+    `CHECK_INTERVAL_MINUTES must be a positive number, got "${process.env.CHECK_INTERVAL_MINUTES}"`
+  );
+  process.exit(1);
+}
+
+if (isNaN(config.nightSleepStart) || config.nightSleepStart < 0 || config.nightSleepStart > 23) {
+  console.error(
+    `NIGHT_SLEEP_START must be an integer between 0 and 23, got "${process.env.NIGHT_SLEEP_START}"`
+  );
+  process.exit(1);
+}
+
+if (isNaN(config.nightSleepEnd) || config.nightSleepEnd < 0 || config.nightSleepEnd > 23) {
+  console.error(
+    `NIGHT_SLEEP_END must be an integer between 0 and 23, got "${process.env.NIGHT_SLEEP_END}"`
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Validates `CHECK_INTERVAL_MINUTES` is a positive number (> 0); errors on NaN or non-positive values
- Validates `NIGHT_SLEEP_START` and `NIGHT_SLEEP_END` are integers between 0 and 23; errors on NaN or out-of-range values
- Uses the same `console.error` + `process.exit(1)` pattern as existing config validation

## Test plan
- [ ] Set `CHECK_INTERVAL_MINUTES=-5` and verify the app exits with a clear error
- [ ] Set `CHECK_INTERVAL_MINUTES=abc` and verify the app exits with a clear error
- [ ] Set `NIGHT_SLEEP_START=99` and verify the app exits with a clear error
- [ ] Set `NIGHT_SLEEP_END=-1` and verify the app exits with a clear error
- [ ] Verify default values (30, 0, 8) still work when env vars are unset
- [ ] Run `pnpm build` to confirm no TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)