### PR TITLE
Log errors in scrapePostPage instead of silently swallowing them

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -148,7 +148,8 @@ async function scrapePostPage(
     }
 
     return { id: contentFingerprint(text), text, link, images, pageName };
-  } catch {
+  } catch (err) {
+    console.warn(`  Failed to scrape post ${link}:`, err instanceof Error ? err.message : err);
     return null;
   } finally {
     await postPage.close();


### PR DESCRIPTION
## Summary
- Replace the bare `catch {}` block in `scrapePostPage()` with a `catch (err)` that logs a warning via `console.warn`, including the post URL and error message
- Other bare `catch {}` blocks (`dismissPopups`, `extractPermalink`, `cleanFacebookUrl`) are intentionally left silent since they handle expected/harmless failures

## Test plan
- [ ] Run `pnpm build` -- passes with no TypeScript errors
- [ ] Trigger a scrape failure (e.g., invalid URL) and confirm the warning appears in console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)