### PR TITLE
Add user agent rotation to reduce detection risk

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,3 +20,10 @@ export const DELAYS = {
   SCROLL: { min: 2000, max: 4000 },
   BETWEEN_ARTICLES: { min: 300, max: 800 },
 } as const;
+
+export const USER_AGENTS = [
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36",
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+] as const;

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -4,7 +4,7 @@ import stealth from "puppeteer-extra-plugin-stealth";
 import { createHash } from "crypto";
 import { writeFileSync, mkdirSync } from "fs";
 import { config } from "./config.js";
-import { TIMEOUTS, LIMITS, DELAYS } from "./constants.js";
+import { TIMEOUTS, LIMITS, DELAYS, USER_AGENTS } from "./constants.js";
 
 chromium.use(stealth());
 
@@ -164,9 +164,9 @@ export async function scrapePage(pageUrl: string): Promise<ScrapeResult> {
   });
 
   try {
+    const userAgent = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
     const context = await browser.newContext({
-      userAgent:
-        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+      userAgent,
       locale: "en-US",
       viewport: { width: 1280, height: 900 },
     });


### PR DESCRIPTION
## Summary
- Replaced the single hardcoded Chrome 131 user agent string with an array of 4 recent user agents (Chrome 131-134 on Windows and Mac)
- A random user agent is selected on each `scrapePage()` call, varying the browser fingerprint across scraping sessions
- The `USER_AGENTS` array is defined in `constants.ts` alongside other configuration constants for easy future updates

## Test plan
- [ ] Verify `pnpm build` compiles without errors
- [ ] Confirm scraping still works end-to-end with the rotated user agents
- [ ] Check logs to see different user agents being used across runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)