### PR TITLE
Reuse browser instance across page checks

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -157,21 +157,25 @@ async function scrapePostPage(
   }
 }
 
-export async function scrapePage(pageUrl: string): Promise<ScrapeResult> {
-  const browser = await chromium.launch({
+export async function launchBrowser() {
+  return chromium.launch({
     headless: true,
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
   });
+}
 
+export async function createBrowserContext(browser: any) {
+  const userAgent = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
+  return browser.newContext({
+    userAgent,
+    locale: "en-US",
+    viewport: { width: 1280, height: 900 },
+  });
+}
+
+export async function scrapePage(pageUrl: string, context: any): Promise<ScrapeResult> {
+  const page = await context.newPage();
   try {
-    const userAgent = USER_AGENTS[Math.floor(Math.random() * USER_AGENTS.length)];
-    const context = await browser.newContext({
-      userAgent,
-      locale: "en-US",
-      viewport: { width: 1280, height: 900 },
-    });
-
-    const page = await context.newPage();
     await page.goto(pageUrl, { waitUntil: "networkidle", timeout: TIMEOUTS.BROWSER });
 
     await dismissPopups(page);
@@ -223,6 +227,6 @@ export async function scrapePage(pageUrl: string): Promise<ScrapeResult> {
 
     return { posts, blocked: false, pageName, elementCount: count };
   } finally {
-    await browser.close();
+    await page.close();
   }
 }


### PR DESCRIPTION
## Summary
- Refactored `scrapePage()` to accept a `BrowserContext` parameter instead of launching its own browser
- Exported `launchBrowser()` and `createBrowserContext()` helpers from `scraper.ts`
- Updated `check()` in `index.ts` to create one browser per check cycle, share it across all page scrapes, and close it in a `try/finally` block

## Motivation
Previously, every call to `scrapePage()` launched a new Chromium instance. When monitoring N pages, that meant N full browser launches per check cycle. Chromium startup is expensive (~1-2s each), so this added significant overhead and resource usage.

Now the browser is launched once, a single `BrowserContext` is created, and each `scrapePage()` call opens a new page tab within that context. The browser is always cleaned up via `try/finally`, even if an error occurs mid-cycle.

## Test plan
- [ ] Verify `pnpm build` succeeds with no TypeScript errors
- [ ] Run with multiple pages configured and confirm all pages are checked in a single browser session
- [ ] Confirm the browser is properly closed after the check cycle (no zombie Chromium processes)
- [ ] Confirm error in one page does not prevent other pages from being checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)