### PR TITLE
Improve TypeScript strictness: proper types and ESM config

### DIFF
--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -1,4 +1,5 @@
 import { chromium } from "playwright-extra";
+import type { Page, BrowserContext, Locator } from "playwright";
 import stealth from "puppeteer-extra-plugin-stealth";
 import { createHash } from "crypto";
 import { writeFileSync, mkdirSync } from "fs";
@@ -76,7 +77,7 @@ function cleanFacebookUrl(url: string): string {
   }
 }
 
-async function dismissPopups(page: any) {
+async function dismissPopups(page: Page) {
   try {
     const cookieBtn = page.locator(
       'button:has-text("Allow all cookies"), button:has-text("Decline optional cookies"), ' +
@@ -97,7 +98,7 @@ async function dismissPopups(page: any) {
   }
 }
 
-async function extractPermalink(el: any): Promise<string | null> {
+async function extractPermalink(el: Locator): Promise<string | null> {
   try {
     const permalinks = el.locator(
       'a[href*="/posts/"], a[href*="/photos/"], a[href*="story_fbid"], a[href*="/videos/"], a[href*="/permalink/"]'
@@ -113,7 +114,7 @@ async function extractPermalink(el: any): Promise<string | null> {
 }
 
 async function scrapePostPage(
-  context: any,
+  context: BrowserContext,
   link: string,
   pageName: string
 ): Promise<FacebookPost | null> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
-    "moduleResolution": "node",
+    "module": "node16",
+    "moduleResolution": "node16",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary
- **Fix `tsconfig.json` ESM config**: Change `module` and `moduleResolution` from `"ES2022"`/`"node"` to `"node16"`/`"node16"` for proper ESM module resolution
- **Replace `any` types in `scraper.ts`**: Import `Page`, `BrowserContext`, `Locator` from Playwright and use them in `dismissPopups()`, `extractPermalink()`, and `scrapePostPage()` signatures
- Build verified clean with `pnpm build` — no TypeScript errors

## Test plan
- [x] `pnpm build` compiles without errors
- [ ] Verify runtime behavior is unchanged (scraping + telegram posting still work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)