### PR TITLE
Add Coolify deployment guide and docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,32 @@ docker build -t social-relay .
 docker run -d --env-file .env -v ./data:/app/data social-relay
 ```
 
+### Docker Compose
+
+```bash
+cp .env.example .env
+# fill in your values
+docker compose up -d
+```
+
+### Coolify
+
+This is a background worker (no HTTP port), so the Docker Compose build pack works best.
+
+1. In Coolify, create a new resource and connect your repo (or use the public GitHub URL)
+2. Select **Docker Compose** as the build pack
+3. Go to **Environment Variables** and add:
+   - `TELEGRAM_BOT_TOKEN` (required)
+   - `TELEGRAM_CHAT_ID` (required)
+   - `FACEBOOK_PAGES` (required)
+   - Any optional vars from the [Configuration](#configuration) table
+4. Go to **Storages** and add a volume with destination `/app/data` — this keeps the sent-post history across deploys
+5. Under **General** settings, clear the **Domains** field (this is a worker, not a web app)
+6. Disable **Health Check** — there's no HTTP endpoint to check
+7. Deploy
+
+The included `docker-compose.yml` already sets `shm_size: 1gb` (needed for Chromium) and `restart: unless-stopped`.
+
 ## Configuration
 
 | Variable | Required | Default | Description |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  social-relay:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    shm_size: '1gb'
+    volumes:
+      - social-relay-data:/app/data
+    environment:
+      - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
+      - TELEGRAM_CHAT_ID=${TELEGRAM_CHAT_ID}
+      - FACEBOOK_PAGES=${FACEBOOK_PAGES}
+      - CHECK_INTERVAL_MINUTES=${CHECK_INTERVAL_MINUTES:-30}
+      - TIMEZONE=${TIMEZONE:-UTC}
+      - NIGHT_SLEEP_START=${NIGHT_SLEEP_START:-0}
+      - NIGHT_SLEEP_END=${NIGHT_SLEEP_END:-8}
+      - BOT_LANGUAGE=${BOT_LANGUAGE:-en}
+      - DEBUG=${DEBUG:-0}
+
+volumes:
+  social-relay-data:

--- a/src/scraper.ts
+++ b/src/scraper.ts
@@ -160,7 +160,7 @@ async function scrapePostPage(
 export async function launchBrowser() {
   return chromium.launch({
     headless: true,
-    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+    args: ["--no-sandbox", "--disable-setuid-sandbox", "--disable-dev-shm-usage"],
   });
 }
 


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with `shm_size: 1gb` (for Chromium) and a named volume for `/app/data` persistence
- Add Coolify deployment section to README with step-by-step instructions (Docker Compose build pack, no HTTP port, disable health check)
- Add Docker Compose section to README
- Add `--disable-dev-shm-usage` to Chromium launch args to prevent crashes in Docker's default 64MB `/dev/shm`

## Test plan
- [ ] Verify `docker compose up -d` works with a valid `.env`
- [ ] Verify Coolify deployment following the README steps
- [ ] Confirm `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)