### PR TITLE
Fix Playwright browser path for non-root Docker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json pnpm-lock.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Install Playwright browser + OS deps after pnpm install so it uses the locked version
+ENV PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright
 RUN pnpm exec playwright install --with-deps chromium
 
 COPY tsconfig.json ./


### PR DESCRIPTION
## Summary
- Set `PLAYWRIGHT_BROWSERS_PATH=/app/.cache/ms-playwright` before browser install so both build (root) and runtime (appuser) use the same path
- Without this, browsers installed to `/root/.cache/` during build are invisible to `appuser` at runtime (home = `/app`)
- Regression from #28 (non-root user)

## Test plan
- [x] Rebuild Docker image and verify the bot starts without Playwright "executable doesn't exist" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)